### PR TITLE
Let USB installation script accept multiple NSP path, files and patterns

### DIFF
--- a/tools/usb_install_pc.py
+++ b/tools/usb_install_pc.py
@@ -30,11 +30,16 @@ import struct
 import sys
 from binascii import hexlify as hx, unhexlify as uhx
 from pathlib import Path
+from glob import glob
+import os
 
 CMD_ID_EXIT = 0
 CMD_ID_FILE_RANGE = 1
 
 CMD_TYPE_RESPONSE = 1
+
+def flatMap(func, myList):
+    return [j for i in myList for j in func(i)]
 
 def send_response_header(out_ep, cmd_id, data_size):
     out_ep.write(b'TUC0') # Tinfoil USB Command 0
@@ -44,7 +49,7 @@ def send_response_header(out_ep, cmd_id, data_size):
     out_ep.write(struct.pack('<Q', data_size))
     out_ep.write(b'\x00' * 0xC)
 
-def file_range_cmd(nsp_dir, in_ep, out_ep, data_size):
+def file_range_cmd(in_ep, out_ep, data_size):
     file_range_header = in_ep.read(0x20)
 
     range_size = struct.unpack('<Q', file_range_header[:8])[0]
@@ -71,7 +76,7 @@ def file_range_cmd(nsp_dir, in_ep, out_ep, data_size):
             out_ep.write(data=buf, timeout=0)
             curr_off += read_size
 
-def poll_commands(nsp_dir, in_ep, out_ep):
+def poll_commands(in_ep, out_ep):
     while True:
         cmd_header = bytes(in_ep.read(0x20, timeout=0))
         magic = cmd_header[:4]
@@ -90,27 +95,22 @@ def poll_commands(nsp_dir, in_ep, out_ep):
             print('Exiting...')
             break
         elif cmd_id == CMD_ID_FILE_RANGE:
-            file_range_cmd(nsp_dir, in_ep, out_ep, data_size)
+            file_range_cmd(in_ep, out_ep, data_size)
 
-def send_nsp_list(nsp_dir, out_ep):
-    nsp_path_list = list()
-    nsp_path_list_len = 0
-
-    # Add all files with the extension .nsp in the provided dir
-    for nsp_path in [f for f in nsp_dir.iterdir() if f.is_file() and f.suffix == '.nsp']:
-        nsp_path_list.append(nsp_path.__str__() + '\n')
-        nsp_path_list_len += len(nsp_path.__str__()) + 1
-
+def send_nsp_list(nsp_path_list, out_ep):
     print('Sending header...')
 
+    nsp_list = list(map(lambda path: str(path) + '\n', nsp_path_list))
+
     out_ep.write(b'TUL0') # Tinfoil USB List 0
-    out_ep.write(struct.pack('<I', nsp_path_list_len))
+    out_ep.write(struct.pack('<I', sum(map(len, nsp_list))))
     out_ep.write(b'\x00' * 0x8) # Padding
 
-    print('Sending NSP list: {}'.format(nsp_path_list))
+    print('Sending NSP list: {}'.format(nsp_list))
     
-    for nsp_path in nsp_path_list:
+    for nsp_path in nsp_list:
         out_ep.write(nsp_path)
+
 
 def print_usage():
     print("""\
@@ -118,17 +118,25 @@ usb_install_pc.py
 
 Used for the installation of NSPs over USB.
 
-Usage: usb_install_pc.py <nsp folder>""")
+Usage: usb_install_pc.py <nsp path|file pattern> [<nsp path|file pattern> ...]""")
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2:
         print_usage()
         sys.exit(1)
 
-    nsp_dir = Path(sys.argv[1])
+    nsps = list(
+        filter(lambda path: os.path.isfile(path) and path.endswith('.nsp'),
+            flatMap(
+                lambda path: map(str, Path(path).iterdir()) if os.path.isdir(path) else [path] if os.path.isfile(path) else glob(path),
+                sys.argv[1:]
+            )
+        )
+    )
 
-    if not nsp_dir.is_dir():
-        raise ValueError('1st argument must be a directory')
+    if len(nsps) == 0:
+        print("No nsp files found/specified")
+        sys.exit(1)
 
     # Find the switch
     dev = usb.core.find(idVendor=0x057E, idProduct=0x3000)
@@ -148,5 +156,5 @@ if __name__ == '__main__':
     assert out_ep is not None
     assert in_ep is not None
 
-    send_nsp_list(nsp_dir, out_ep)
-    poll_commands(nsp_dir, in_ep, out_ep)    
+    send_nsp_list(nsps, out_ep)
+    poll_commands(in_ep, out_ep)


### PR DESCRIPTION
```
usb_install_py.py C:/somepath C:/someotherpath
usb_install_py.py C:/somepath/homebrew*.nsp
usb_install_py.py C:/somepath/homebrew1.nsp C:/somepath/homebrew2.nsp C:/someotherpath/homebrewN.nsp
```

Also supports dragging an NSP onto the python script if pyhon execution is correctly setup on windows.