### PR TITLE
fixed ncm content meta-database resource leak

### DIFF
--- a/Source/gleaf/nsp/Installer.cpp
+++ b/Source/gleaf/nsp/Installer.cpp
@@ -177,7 +177,7 @@ namespace gleaf::nsp
             serviceClose(&metadb.s);
             return this->irc;
         }
-		serviceClose(&metadb.s);
+        serviceClose(&metadb.s);
         std::vector<ns::ContentStorageRecord> records;
         basetid = horizon::GetBaseApplicationId(metakey.titleId, static_cast<ncm::ContentMetaType>(metakey.type));
         std::tuple<Result, u32> nst = ns::CountApplicationContentMeta(basetid);

--- a/Source/gleaf/nsp/Installer.cpp
+++ b/Source/gleaf/nsp/Installer.cpp
@@ -177,6 +177,7 @@ namespace gleaf::nsp
             serviceClose(&metadb.s);
             return this->irc;
         }
+		serviceClose(&metadb.s);
         std::vector<ns::ContentStorageRecord> records;
         basetid = horizon::GetBaseApplicationId(metakey.titleId, static_cast<ncm::ContentMetaType>(metakey.type));
         std::tuple<Result, u32> nst = ns::CountApplicationContentMeta(basetid);


### PR DESCRIPTION
fixed ncm content meta-database resource leak that would crash the switch after 24 installs.