### PR TITLE
Print cwd while user scroll between folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+*.json
+*.d
+*.o
+*.lst
+*.map
+*.dat

--- a/Goldleaf/Include/gleaf/ui/MainApplication.hpp
+++ b/Goldleaf/Include/gleaf/ui/MainApplication.hpp
@@ -190,6 +190,8 @@ namespace gleaf::ui
             void sysInfo_Input(u64 Down, u64 Up, u64 Held);
             void about_Input(u64 Down, u64 Up, u64 Held);
             void OnInput(u64 Down, u64 Up, u64 Held);
+            void SetPathBrowsed(std::string path);
+            std::string GetPathBrowsed();
             MainMenuLayout *GetMainMenuLayout();
             PartitionBrowserLayout *GetSDBrowserLayout();
             PartitionBrowserLayout *GetNANDBrowserLayout();
@@ -224,6 +226,7 @@ namespace gleaf::ui
             pu::element::Image *batteryImage;
             pu::element::Image *batteryChargeImage;
             pu::element::TextBlock *footerText;
+            pu::element::TextBlock *pathBrowsed;
     };
 
     void UpdateClipboard(std::string Path);

--- a/Goldleaf/Source/gleaf/ui/MainApplication.cpp
+++ b/Goldleaf/Source/gleaf/ui/MainApplication.cpp
@@ -6,6 +6,7 @@ namespace gleaf::ui
     MainApplication *mainapp;
     std::string clipboard;
     std::string current_cwd = "";
+    u32 cwd_fsize = 23;
 
     MainMenuLayout::MainMenuLayout() : pu::Layout()
     {
@@ -142,9 +143,10 @@ namespace gleaf::ui
     void PartitionBrowserLayout::UpdateElements()
     {
         current_cwd = this->gexp->GetCwd();
-        if (current_cwd.length() > 70) 
+        size_t max_chars = 220 - 6*cwd_fsize;
+        if (current_cwd.length() > max_chars) 
         {
-            current_cwd = current_cwd.substr(0,70);
+            current_cwd = current_cwd.substr(0,max_chars);
             current_cwd += "...";
         }
         if(!this->elems.empty()) this->elems.clear();
@@ -1646,8 +1648,9 @@ namespace gleaf::ui
         this->preisch = false;
         this->pretime = "";
         this->vfirst = true;
-        this->pathBrowsed = new pu::element::TextBlock(40, 135, "");
-        this->pathBrowsed->SetColor({ 222, 167, 5, 255 }); // #DEA705
+        this->pathBrowsed = new pu::element::TextBlock(15, 135, "", cwd_fsize);
+        //this->pathBrowsed->SetColor({ 222, 167, 5, 255 }); // #dea705 goldleaf yellow
+        this->pathBrowsed->SetColor({ 178, 134, 4, 255 }); // #b28604 25% darker ^
         this->timeText = new pu::element::TextBlock(1070, 50, horizon::GetCurrentTime());
         this->batteryImage = new pu::element::Image(1200, 35, "romfs:/Battery/0.png");
         this->batteryChargeImage = new pu::element::Image(1200, 35, "romfs:/Battery/Charge.png");

--- a/Goldleaf/Source/gleaf/ui/MainApplication.cpp
+++ b/Goldleaf/Source/gleaf/ui/MainApplication.cpp
@@ -142,6 +142,11 @@ namespace gleaf::ui
     void PartitionBrowserLayout::UpdateElements()
     {
         current_cwd = this->gexp->GetCwd();
+        if (current_cwd.length() > 70) 
+        {
+            current_cwd = current_cwd.substr(0,70);
+            current_cwd += "...";
+        }
         if(!this->elems.empty()) this->elems.clear();
         this->elems = this->gexp->GetContents();
         this->browseMenu->ClearItems();

--- a/Goldleaf/Source/gleaf/ui/MainApplication.cpp
+++ b/Goldleaf/Source/gleaf/ui/MainApplication.cpp
@@ -65,7 +65,6 @@ namespace gleaf::ui
     {
         mainapp->GetSDBrowserLayout()->UpdateElements();
         mainapp->LoadLayout(mainapp->GetSDBrowserLayout());
-        current_cwd = mainapp->GetSDBrowserLayout()->GetExplorer()->GetCwd();
     }
 
     void MainMenuLayout::nandMenuItem_Click()
@@ -84,7 +83,6 @@ namespace gleaf::ui
         else if(sopt == 2) mainapp->GetNANDBrowserLayout()->ChangePartition(fs::Partition::NANDUser);
         else if(sopt == 3) mainapp->GetNANDBrowserLayout()->ChangePartition(fs::Partition::NANDSystem);
         mainapp->LoadLayout(mainapp->GetNANDBrowserLayout());
-        current_cwd = mainapp->GetNANDBrowserLayout()->GetExplorer()->GetCwd();
     }
 
     void MainMenuLayout::usbMenuItem_Click()
@@ -1643,7 +1641,7 @@ namespace gleaf::ui
         this->preisch = false;
         this->pretime = "";
         this->vfirst = true;
-        this->pathBrowsed = new pu::element::TextBlock(40, 140, "");
+        this->pathBrowsed = new pu::element::TextBlock(40, 135, "");
         this->pathBrowsed->SetColor({ 222, 167, 5, 255 }); // #DEA705
         this->timeText = new pu::element::TextBlock(1070, 50, horizon::GetCurrentTime());
         this->batteryImage = new pu::element::Image(1200, 35, "romfs:/Battery/0.png");
@@ -1765,7 +1763,7 @@ namespace gleaf::ui
             if(this->sdBrowser->GoBack()) this->sdBrowser->UpdateElements();
             else {
                 this->LoadLayout(this->mainMenu);
-                SetPathBrowsed("");
+                current_cwd = "";
             }
         }
         else if(Down & KEY_X)
@@ -1842,7 +1840,7 @@ namespace gleaf::ui
             if(this->nandBrowser->GoBack()) this->nandBrowser->UpdateElements();
             else {
                 this->LoadLayout(this->mainMenu);
-                SetPathBrowsed("");
+                current_cwd = "";
             }
         }
         else if(Down & KEY_X)


### PR DESCRIPTION
Compatible with both SD and NAND browsing, it shows the cwd the user is in. 
A known problem: if a path is too long, it will go on a new line (maybe autoresize or just a trimmed path with dots?).
EDIT: Fixed! Added dots ("...") to the end of cwd