### PR TITLE
Fix jfoenix for java 9+

### DIFF
--- a/Quark/pom.xml
+++ b/Quark/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.jfoenix</groupId>
             <artifactId>jfoenix</artifactId>
-            <version>8.0.8</version>
+            <version>9.0.8</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.usb4java/usb4java -->
         <dependency>


### PR DESCRIPTION
The issue is caused due to FXML API changes between Java 8 and Java 9. This updates the jfoenix dependency to the one used in Java 9 upwards.

Tested on Arch Linux with the following Java versions:

- `java-8-openjdk`
- `java-13-openjdk`

--

This PR closes XorTroll/Goldleaf#392 and closes XorTroll/Goldleaf#407