### PR TITLE
Update QUARK_LINUX.md

### DIFF
--- a/docs/QUARK_LINUX.md
+++ b/docs/QUARK_LINUX.md
@@ -24,6 +24,12 @@ Set udev rule or run java as root. Ensure maven and JDK11 are installed and set 
     cd Goldleaf/Quark
     mvn -B -DskipTests clean package
     java -jar target/Quark.jar
+    
+## Requirements
+
+On Fedora and Fedora Silverblue, the following packages are required in order to run Quark.
+
+    sudo dnf install java-1.8.0-openjdk java-1.8.0-openjdk-openjfx
 
 ## Important notes
 


### PR DESCRIPTION
Added instructions for Fedora users for getting JavaFX. This is not trivial as the `openfx` package alone does not suffice.