### PR TITLE
Add a command line option to set the configuration file.

### DIFF
--- a/Quark/src/main/java/org/docopt/Argument.java
+++ b/Quark/src/main/java/org/docopt/Argument.java
@@ -1,0 +1,29 @@
+package org.docopt;
+
+import java.util.List;
+
+class Argument extends LeafPattern {
+
+	public Argument(final String name, final Object value) {
+		super(name, value);
+	}
+
+	public Argument(final String name) {
+		super(name);
+	}
+
+	@Override
+	protected SingleMatchResult singleMatch(final List<LeafPattern> left) {
+		// >>> for n, pattern in enumerate(left)
+		for (int n = 0; n < left.size(); n++) {
+			final LeafPattern pattern = left.get(n);
+
+			if (pattern.getClass() == Argument.class) {
+				return new SingleMatchResult(n, new Argument(getName(),
+						pattern.getValue()));
+			}
+		}
+
+		return new SingleMatchResult(null, null);
+	}
+}

--- a/Quark/src/main/java/org/docopt/BranchPattern.java
+++ b/Quark/src/main/java/org/docopt/BranchPattern.java
@@ -1,0 +1,76 @@
+package org.docopt;
+
+import static org.docopt.Python.in;
+import static org.docopt.Python.join;
+import static org.docopt.Python.list;
+
+import java.util.List;
+
+/**
+ * Branch/inner node of a pattern tree.
+ */
+abstract class BranchPattern extends Pattern {
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result
+				+ ((children == null) ? 0 : children.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final BranchPattern other = (BranchPattern) obj;
+		if (children == null) {
+			if (other.children != null) {
+				return false;
+			}
+		}
+		else if (!children.equals(other.children)) {
+			return false;
+		}
+		return true;
+	}
+
+	private final List<Pattern> children;
+
+	public BranchPattern(final List<? extends Pattern> children) {
+		this.children = list(children);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s(%s)", getClass().getSimpleName(),
+				children.isEmpty() ? "" : join(", ", children));
+	}
+
+	@Override
+	protected final List<Pattern> flat(final Class<?>... types) {
+		if (in(getClass(), types)) {
+			return list((Pattern) this);
+		}
+
+		// >>> return sum([child.flat(*types) for child in self.children], [])
+		{
+			final List<Pattern> result = list();
+
+			for (final Pattern child : children) {
+				result.addAll(child.flat(types));
+			}
+
+			return result;
+		}
+	}
+
+	public List<Pattern> getChildren() {
+		return children;
+	}
+}

--- a/Quark/src/main/java/org/docopt/Command.java
+++ b/Quark/src/main/java/org/docopt/Command.java
@@ -1,0 +1,31 @@
+package org.docopt;
+
+import java.util.List;
+
+final class Command extends Argument {
+
+	public Command(final String name, final Object value) {
+		super(name, value);
+	}
+
+	public Command(final String name) {
+		this(name, false);
+	}
+
+	@Override
+	protected SingleMatchResult singleMatch(final List<LeafPattern> left) {
+		for (int n = 0; n < left.size(); n++) {
+			final LeafPattern pattern = left.get(n);
+
+			if (pattern.getClass() == Argument.class) {
+				if (getName().equals(pattern.getValue())) {
+					return new SingleMatchResult(n,
+							new Command(getName(), true));
+				}
+				break;
+			}
+		}
+
+		return new SingleMatchResult(null, null);
+	}
+}

--- a/Quark/src/main/java/org/docopt/Docopt.java
+++ b/Quark/src/main/java/org/docopt/Docopt.java
@@ -1,0 +1,973 @@
+package org.docopt;
+
+import static org.docopt.Python.bool;
+import static org.docopt.Python.in;
+import static org.docopt.Python.isUpper;
+import static org.docopt.Python.join;
+import static org.docopt.Python.list;
+import static org.docopt.Python.partition;
+import static org.docopt.Python.set;
+import static org.docopt.Python.split;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.docopt.Pattern.MatchResult;
+import org.docopt.Python.Re;
+
+// @formatter:off
+/**
+ * Command-line interface parser that will make you smile.
+ * <p>
+ * Parses arguments based on the same POSIX-style usage pattern that would be
+ * displayed when using the --help option. Simplifies handling command line
+ * arguments and ensures that the parser is consistent with the documentation.
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * class NavalFate {
+ *
+ *   private static final String doc =
+ *       &quot;Naval Fate.\n&quot;
+ *       + &quot;\n&quot;
+ *       + &quot;Usage:\n&quot;
+ *       + &quot;  naval_fate ship new &lt;name&gt;...\n&quot;
+ *       + &quot;  naval_fate ship &lt;name&gt; move &lt;x&gt; &lt;y&gt; [--speed=&lt;kn&gt;]\n&quot;
+ *       + &quot;  naval_fate ship shoot &lt;x&gt; &lt;y&gt;\n&quot;
+ *       + &quot;  naval_fate mine (set|remove) &lt;x&gt; &lt;y&gt; [--moored | --drifting]\n&quot;
+ *       + &quot;  naval_fate (-h | --help)\n&quot;
+ *       + &quot;  naval_fate --version\n&quot;
+ *       + &quot;\n&quot;
+ *       + &quot;Options:\n&quot;
+ *       + &quot;  -h --help     Show this screen.\n&quot;
+ *       + &quot;  --version     Show version.\n&quot;
+ *       + &quot;  --speed=&lt;kn&gt;  Speed in knots [default: 10].\n&quot;
+ *       + &quot;  --moored      Moored (anchored) mine.\n&quot;
+ *       + &quot;  --drifting    Drifting mine.\n&quot;
+ *       + &quot;\n&quot;;
+ *
+ *   public static void main(String[] args) {
+ *     Map&lt;String, Object&gt; opts =
+ *         new Docopt(doc).withVersion(&quot;Naval Fate 2.0&quot;).parse(args);
+ *     System.out.println(opts);
+ *   }
+ * }
+ * </pre>
+ *
+ * Licensed under terms of MIT license (see LICENSE).
+ * <p>
+ * Copyright (c) 2012 Vladimir Keleshev, vladimir@keleshev.com<br />
+ * Copyright (c) 2014 Damien Giese, damien.giese@gmail.com
+ *
+ * @version 0.6.0
+ * @see <a href="http://docopt.org">docopt.org</a>
+ * @see <a href="https://github.com/docopt/docopt.java">docopt for Java</a>
+ */
+// @formatter:on
+public final class Docopt {
+
+	/**
+	 * <pre>
+	 * long ::= '--' chars [ ( ' ' | '=' ) chars ] ;
+	 * </pre>
+	 */
+	private static List<Option> parseLong(final Tokens tokens,
+			final List<Option> options) {
+
+		String $long;
+		String eq;
+		String value;
+
+		// >>> long, eq, value = tokens.move().partition('=')
+		{
+			final String[] a = partition(tokens.move(), "=");
+			$long = a[0];
+			eq = a[1];
+			value = a[2];
+		}
+
+		assert $long.startsWith("--");
+
+		// >>> value = None if eq == value == '' else value
+		if ("".equals(eq) && "".equals(value)) {
+			value = null;
+		}
+
+		List<Option> similar;
+
+		// >>> similar = [o for o in options if o.long == long]
+		{
+			similar = list();
+
+			for (final Option o : options) {
+				if ($long.equals(o.getLong())) {
+					similar.add(o);
+				}
+			}
+		}
+
+		if (tokens.getError() == DocoptExitException.class && similar.isEmpty()) {
+// @formatter:off
+			// >>> similar = [o for o in options if o.long and  o.long.startswith(long)]
+			// @formatter:on
+			{
+				for (final Option o : options) {
+					if (o.getLong() != null && o.getLong().startsWith($long)) {
+						similar.add(o);
+					}
+				}
+			}
+		}
+
+		if (similar.size() > 1) {
+			List<String> u;
+
+			// >>> o.long for o in similar
+			{
+				u = list();
+				for (final Option o : similar) {
+					u.add(o.getLong());
+				}
+			}
+
+			throw tokens.error("%s is not a unique prefix: %s?", $long,
+					join(", ", u));
+		}
+
+		Option o;
+
+		if (similar.size() < 1) {
+			final int argCount = "=".equals(eq) ? 1 : 0;
+
+			o = new Option(null, $long, argCount);
+
+			options.add(o);
+
+			if (tokens.getError() == DocoptExitException.class) {
+				// @formatter:off
+				// >>> o = Option(None, long, argcount, value if argcount else True)
+				// @formatter:on
+				o = new Option(null, $long, argCount, (argCount != 0) ? value
+						: true);
+			}
+		}
+		else {
+// @formatter:off
+			// >>> o = Option(similar[0].short, similar[0].long,
+			// >>>            similar[0].argcount, similar[0].value)
+			// @formatter:on
+			{
+				final Option u = similar.get(0);
+				o = new Option(u.getShort(), u.getLong(), u.getArgCount(),
+						u.getValue());
+			}
+
+			if (o.getArgCount() == 0) {
+				if (value != null) {
+					throw tokens.error("%s must not have an argument",
+							o.getLong());
+				}
+			}
+			else {
+				if (value == null) {
+					// >>> if tokens.current() in [None, '--']
+					{
+						final String u = tokens.current();
+						if (u == null || "--".equals(u)) {
+							throw tokens.error("%s requires argument",
+									o.getLong());
+						}
+					}
+
+					value = tokens.move();
+				}
+			}
+
+			if (tokens.getError() == DocoptExitException.class) {
+				o.setValue((value != null) ? value : true);
+			}
+		}
+
+		return list(o);
+	}
+
+	/**
+	 * <pre>
+	 * shorts ::= '-' ( chars )* [ [ ' ' ] chars ] ;
+	 * </pre>
+	 */
+	private static List<Option> parseShorts(final Tokens tokens,
+			final List<Option> options) {
+		final String token = tokens.move();
+		assert token.startsWith("-") && !token.startsWith("--");
+		String left = token.replaceFirst("^-+", "");
+
+		final List<Option> parsed = list();
+
+		while (!"".equals(left)) {
+			final String $short = "-" + left.charAt(0);
+
+			left = left.substring(1);
+
+			List<Option> similar;
+
+			// >>> similar = [o for o in options if o.short == short]
+			{
+				similar = list();
+
+				for (final Option o : options) {
+					if ($short.equals(o.getShort())) {
+						similar.add(o);
+					}
+				}
+			}
+
+			if (similar.size() > 1) {
+				throw tokens.error("%s is specified ambiguously %d times",
+						$short, similar.size());
+			}
+
+			Option o;
+
+			if (similar.size() < 1) {
+				o = new Option($short, null, 0);
+
+				options.add(o);
+
+				if (tokens.getError() == DocoptExitException.class) {
+					o = new Option($short, null, 0, true);
+				}
+			}
+			else {
+// @formatter:off
+				// >>> o = Option(short, similar[0].long,
+				// >>>            similar[0].argcount, similar[0].value)
+				// @formatter:on
+				{
+					final Option u = similar.get(0);
+					o = new Option($short, u.getLong(), u.getArgCount(),
+							u.getValue());
+				}
+
+				String value = null;
+
+				if (o.getArgCount() != 0) {
+					if ("".equals(left)) {
+						// >>> if tokens.current() in [None, '--']
+						{
+							final String u = tokens.current();
+							if (u == null || "--".equals(u)) {
+								throw tokens.error("%s requires argument",
+										$short);
+							}
+							value = tokens.move();
+						}
+					}
+					else {
+						value = left;
+						left = "";
+					}
+				}
+
+				if (tokens.getError() == DocoptExitException.class) {
+					o.setValue((value != null) ? value : true);
+				}
+			}
+
+			parsed.add(o);
+		}
+
+		return parsed;
+	}
+
+	private static Required parsePattern(final String source,
+			final List<Option> options) {
+		final Tokens tokens = Tokens.fromPattern(source);
+		final List<? extends Pattern> result = parseExpr(tokens, options);
+
+		if (tokens.current() != null) {
+			throw tokens.error("unexpected ending: %s", join(" ", tokens));
+		}
+
+		return new Required(result);
+	}
+
+	/**
+	 * <pre>
+	 * expr ::= seq ( '|' seq )* ;
+	 * </pre>
+	 */
+	private static List<? extends Pattern> parseExpr(final Tokens tokens,
+			final List<Option> options) {
+		List<Pattern> seq = parseSeq(tokens, options);
+
+		if (!"|".equals(tokens.current())) {
+			return seq;
+		}
+
+		final List<Pattern> result = (seq.size() > 1) ? list((Pattern) new Required(
+				seq))
+				: seq;
+
+		while ("|".equals(tokens.current())) {
+			tokens.move();
+			seq = parseSeq(tokens, options);
+			result.addAll((seq.size() > 1) ? list(new Required(seq)) : seq);
+		}
+
+		return (result.size() > 1) ? list(new Either(result)) : result;
+	}
+
+	/**
+	 * <pre>
+	 * seq ::= ( atom [ '...' ] )* ;
+	 * </pre>
+	 */
+	private static List<Pattern> parseSeq(final Tokens tokens,
+			final List<Option> options) {
+		final List<Pattern> result = list();
+
+		// >>> while tokens.current() not in [None, ']', ')', '|']
+		while (!in(tokens.current(), null, "]", ")", "|")) {
+			List<? extends Pattern> atom = parseAtom(tokens, options);
+
+			if ("...".equals(tokens.current())) {
+				atom = list(new OneOrMore(atom));
+				tokens.move();
+			}
+
+			result.addAll(atom);
+		}
+
+		return result;
+	}
+
+	// @formatter:off
+	/**
+	 * <pre>
+	 * atom ::= '(' expr ')' | '[' expr ']' | 'options' | long | shorts | argument | command ;
+	 * </pre>
+	 */
+	// @formatter:on
+	private static List<? extends Pattern> parseAtom(final Tokens tokens,
+			final List<Option> options) {
+		final String token = tokens.current();
+
+		List<Pattern> result = list();
+
+		if ("(".equals(token) || "[".equals(token)) {
+			tokens.move();
+
+			String matching;
+
+			// @formatter:off
+			// >>> matching, pattern = {'(': [')', Required], '[': [']', Optional]}[token]
+			// >>> result = pattern(*parse_expr(tokens, options))
+			// @formatter:on
+			{
+				final List<? extends Pattern> u = parseExpr(tokens, options);
+
+				if ("(".equals(token)) {
+					matching = ")";
+					result = list((Pattern) new Required(u));
+				}
+				else if ("[".equals(token)) {
+					matching = "]";
+					result = list((Pattern) new Optional(u));
+				}
+				else {
+					throw new IllegalStateException();
+				}
+			}
+
+			if (!matching.equals(tokens.move())) {
+				throw tokens.error("unmatched '%s'", token);
+			}
+
+			return list(result);
+		}
+
+		if ("options".equals(token)) {
+			tokens.move();
+			return list(new OptionsShortcut());
+		}
+
+		if (token.startsWith("--") && !"--".equals(token)) {
+			return parseLong(tokens, options);
+		}
+
+		if (token.startsWith("-") && !("-".equals(token) || "--".equals(token))) {
+			return parseShorts(tokens, options);
+		}
+
+		if ((token.startsWith("<") && token.endsWith(">")) || isUpper(token)) {
+			return list(new Argument(tokens.move()));
+		}
+
+		return list(new Command(tokens.move()));
+	}
+
+	/**
+	 * Parse command-line argument vector.
+	 * <p>
+	 * If {@code optionsFirst} is {@code true}, the arguments must appear in the
+	 * form:
+	 *
+	 * <pre>
+	 * argv ::= [ long | shorts ]* [ argument ]* [ '--' [ argument ]* ] ;
+	 * </pre>
+	 *
+	 * Otherwise, the arguments must appear in the form:
+	 *
+	 * <pre>
+	 * argv ::= [ long | shorts | argument ]* [ '--' [ argument ]* ] ;
+	 * </pre>
+	 */
+	private static List<LeafPattern> parseArgv(final Tokens tokens,
+			final List<Option> options, final boolean optionsFirst) {
+		final List<LeafPattern> parsed = list();
+
+		while (tokens.current() != null) {
+			if ("--".equals(tokens.current())) {
+				// >>> return parsed + [Argument(None, v) for v in tokens]
+				{
+					for (final String v : tokens) {
+						parsed.add(new Argument(null, v));
+					}
+
+					return parsed;
+				}
+			}
+
+			// TODO: Why don't we check for tokens.current != "--" here?
+			if (tokens.current().startsWith("--")) {
+				parsed.addAll(parseLong(tokens, options));
+			}
+			else if (tokens.current().startsWith("-")
+					&& !"-".equals(tokens.current())) {
+				parsed.addAll(parseShorts(tokens, options));
+			}
+			else if (optionsFirst) {
+				// >>> return parsed + [Argument(None, v) for v in tokens]
+				{
+					for (final String v : tokens) {
+						parsed.add(new Argument(null, v));
+					}
+
+					return parsed;
+				}
+			}
+			else {
+				parsed.add(new Argument(null, tokens.move()));
+			}
+		}
+
+		return parsed;
+	}
+
+	private static List<Option> parseDefaults(final String doc) {
+		final List<Option> defaults = list();
+
+		for (String s : parseSection("options:", doc)) {
+			// >>> u, u, s = s.partition(':') # get rid of "options:"
+			{
+				final String[] u = partition(s, ":");
+				s = u[2];
+			}
+
+			List<String> split;
+
+			// >>> split = re.split('\n *(-\S+?)', '\n' + s)[1:]
+			{
+				split = Re.split("\\n *(-\\S+?)", "\n" + s);
+				split.remove(0);
+			}
+
+			// >>> split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])];
+			{
+				final List<String> u = list();
+
+				for (int i = 1; i < split.size(); i += 2) {
+					u.add(split.get(i - 1) + split.get(i));
+				}
+
+				split = u;
+			}
+
+			// @formatter:off
+			// >>> options = [Option.parse(s) for s in split if s.startswith('-')]
+			// >>> defaults += options
+			// @formatter:on
+			{
+				for (final String $s : split) {
+					if ($s.startsWith("-")) {
+						defaults.add(Option.parse($s));
+					}
+				}
+			}
+		}
+
+		return defaults;
+	}
+
+	private static List<String> parseSection(final String name,
+			final String source) {
+		// >>> return [s.strip() for s in pattern.findall(source)]
+		{
+			final List<String> u = Re.findAll("^([^\\n]*" + name +
+					"[^\\n]*\\n?(?:[ \\t].*?(?:\\n|$))*)", source,
+					Re.IGNORECASE | Re.MULTILINE);
+
+			for (int i = 0; i < u.size(); i++) {
+				u.set(i, u.get(i).trim());
+			}
+
+			return u;
+		}
+	}
+
+	private static String formalUsage(String section) {
+		// >>> u, u, section = section.partition(':')
+		{
+			final String[] u = partition(section, ":");
+			section = u[2];
+		}
+
+		final List<String> pu = split(section);
+
+		// @formatter:off
+		// >>> return '( ' + ' '.join(') | (' if s == pu[0] else s for s in pu[1:]) + ' )'
+		// @formatter:on
+		{
+			final StringBuilder sb = new StringBuilder();
+
+			sb.append("( ");
+
+			final String u = pu.remove(0);
+
+			if (!pu.isEmpty()) {
+				for (final String s : pu) {
+					if (s.equals(u)) {
+						sb.append(") | (");
+					}
+					else {
+						sb.append(s);
+					}
+
+					sb.append(" ");
+				}
+
+				sb.setLength(sb.length() - 1);
+			}
+
+			sb.append(" )");
+
+			return sb.toString();
+		}
+	}
+
+	private static void extras(final boolean help, final String version,
+			final List<? extends LeafPattern> options, final String doc) {
+		boolean u;
+
+		// @formatter:off
+		// >>> if help and any((o.name in ('-h', '--help')) and o.value for o in options)
+		// @formatter:on
+		{
+			u = false;
+
+			if (help) {
+				for (final LeafPattern o : options) {
+					if ("-h".equals(o.getName()) | "--help".equals(o.getName())) {
+						if (bool(o.getValue())) {
+							u = true;
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		// Default --help behavior: print documentation and exit with success
+		// status.
+		if (u) {
+			throw new DocoptExitException(0, doc.replaceAll("^\\n+|\\n+$", ""),
+					false);
+		}
+
+		// @formatter:off
+		// >>> if version and any(o.name == '--version' and o.value for o in options)
+		// @formatter:on
+		{
+			u = false;
+
+			if (bool(version)) {
+				for (final LeafPattern o : options) {
+					if ("--version".equals(o.getName())) {
+						u = true;
+						break;
+					}
+				}
+			}
+		}
+
+		// Default --version behavior: print version and exit with success
+		// status.
+		if (u) {
+			throw new DocoptExitException(0, version, false);
+		}
+	}
+
+	static String read(final InputStream stream, final String charset) {
+		final Scanner scanner = new Scanner(stream, charset);
+
+		try {
+			scanner.useDelimiter("\\A");
+			return scanner.hasNext() ? scanner.next() : "";
+		}
+		finally {
+			scanner.close();
+		}
+	}
+
+	static String read(final InputStream stream) {
+		return read(stream, "UTF-8");
+	}
+
+	private final String doc;
+
+	private final String usage;
+
+	private final List<Option> options;
+
+	private final Required pattern;
+
+	private boolean help = true;
+
+	private String version = null;
+
+	private boolean optionsFirst = false;
+
+	private boolean exit = true;
+
+	private PrintStream out = System.out;
+
+	private PrintStream err = System.err;
+
+	/**
+	 * Constructs an argument parser from a POSIX-style help message.
+	 *
+	 * @param doc
+	 *            a POSIX-style help message
+	 * @throws DocoptLanguageError
+	 *             if the help message is malformed
+	 * @see Docopt
+	 */
+	public Docopt(final String doc) {
+		this.doc = doc;
+
+		final List<String> usageSections = parseSection("usage:", doc);
+
+		if (usageSections.size() == 0) {
+			throw new DocoptLanguageError(
+					"\"usage:\" (case-insensitive) not found.");
+		}
+
+		if (usageSections.size() > 1) {
+			throw new DocoptLanguageError(
+					"More than one \"usage:\" (case-insensitive).");
+		}
+
+		usage = usageSections.get(0);
+		options = parseDefaults(doc);
+		pattern = parsePattern(formalUsage(usage), options);
+	}
+
+	/**
+	 * Constructs an argument parser from a POSIX-style help message.
+	 *
+	 * @param stream
+	 *            a stream containing a POSIX-style help message
+	 * @param charset
+	 *            the character encoding of the stream
+	 * @throws DocoptLanguageError
+	 *             if the help message is malformed
+	 * @see Docopt
+	 */
+	public Docopt(final InputStream stream, final Charset charset) {
+		this(read(stream, charset.displayName()));
+	}
+
+	/**
+	 * Constructs an argument parser from a POSIX-style help message.
+	 *
+	 * @param stream
+	 *            a UTF-8 encoded stream containing a POSIX-style help message
+	 * @throws DocoptLanguageError
+	 *             if the help message is malformed
+	 * @see Docopt
+	 */
+	public Docopt(final InputStream stream) {
+		this(read(stream));
+	}
+
+	/**
+	 * If {@code enabled} is {@code true}, the default behavior for the
+	 * {@code --help} (or {@code -h}) option will be used when the
+	 * {@link #parse} method is invoked, causing the parser to display the
+	 * argument to the constructor.
+	 * <p>
+	 * Enabled by default.
+	 *
+	 * @param enabled
+	 *            {@code true} to enable; {@code false} to disable
+	 * @return this object
+	 * @see Docopt
+	 * @see #parse
+	 */
+	public Docopt withHelp(final boolean enabled) {
+		this.help = enabled;
+		return this;
+	}
+
+	/**
+	 * If set to a non-{@code null} value, the {@code --version} option will be
+	 * cause the parser to display the specified string and exit.
+	 *
+	 * @param version
+	 *            the version information to display
+	 * @return this object
+	 */
+	public Docopt withVersion(final String version) {
+		this.version = version;
+		return this;
+	}
+
+	/**
+	 * If set to a non-{@code null} value, the {@code --version} option will be
+	 * cause the parser to display the specified string and exit.
+	 *
+	 * @param stream
+	 *            a stream to read containing the version information
+	 * @param charset
+	 *            the character encoding of {@code stream}
+	 * @return this object
+	 */
+	public Docopt withVersion(final InputStream stream, final Charset charset) {
+		this.version = read(stream, charset.displayName());
+		return this;
+	}
+
+	/**
+	 * If set to a non-{@code null} value, the {@code --version} option will be
+	 * cause the parser to display the specified string and exit.
+	 *
+	 * @param stream
+	 *            a UTF-8 encoded stream to read containing the version
+	 *            information
+	 * @return this object
+	 */
+	public Docopt withVersion(final InputStream stream) {
+		this.version = read(stream);
+		return this;
+	}
+
+	/**
+	 * If {@code enabled} is {@code true}, the parser will require options
+	 * (e.g&#46; {@code --verbose}) to precede positional arguments (e.g&#46;
+	 * FILE).
+	 * <p>
+	 * Disabled by default.
+	 *
+	 * @param enabled
+	 *            {@code true} to enable; {@code false} to disable
+	 * @return this object
+	 */
+	public Docopt withOptionsFirst(final boolean enabled) {
+		this.optionsFirst = enabled;
+		return this;
+	}
+
+	/**
+	 * If {@code enabled} is {@code true}, the parser may terminate the JVM.
+	 * Otherwise, a {@link DocoptExitException} will be thrown instead.
+	 * <p>
+	 * Enabled by default.
+	 *
+	 * @param enabled
+	 *            {@code true} to enable; {@code false} to disable
+	 * @return this object
+	 * @see #parse
+	 * @see #withHelp
+	 * @see #withVersion
+	 */
+	public Docopt withExit(final boolean enabled) {
+		this.exit = enabled;
+		return this;
+	}
+
+	private Map<String, Object> doParse(final List<String> argv) {
+		final List<LeafPattern> $argv = parseArgv(
+				Tokens.withExitException(argv), list(options), optionsFirst);
+		final Set<Pattern> patternOptions = set(pattern.flat(Option.class));
+
+		for (final Pattern optionsShortcut : pattern
+				.flat(OptionsShortcut.class)) {
+// @formatter:off
+			// >>> options_shortcut.children = list(set(doc_options) - pattern_options			// @formatter:on
+			// @formatter:on
+			{
+				final List<Pattern> u = ((BranchPattern) optionsShortcut)
+						.getChildren();
+				u.clear();
+				u.addAll(set(options));
+				Pattern o = null;
+				for (final Iterator<Pattern> i = u.iterator(); i.hasNext();) {
+					o = i.next();
+					for (final Pattern x : patternOptions) {
+						if (o.equals(x)) {
+							i.remove();
+							// Make sure we don't try to remove the same option
+							// twice.
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		extras(help, version, $argv, doc);
+
+		final MatchResult m = pattern.fix().match($argv);
+
+		if (m.matched() && m.getLeft().isEmpty()) {
+			// @formatter:off
+			// >>> return Dict((a.name, a.value) for a in (pattern.flat() + collected))
+			// @formatter:on
+			final Map<String, Object> u = new HashMap<String, Object>();
+
+			for (final Pattern p : pattern.flat()) {
+				// TODO: Does flat always return LeafPattern objects?
+				if (!(p instanceof LeafPattern)) {
+					throw new IllegalStateException();
+				}
+
+				final LeafPattern lp = (LeafPattern) p;
+
+				u.put(lp.getName(), lp.getValue());
+			}
+
+			for (final LeafPattern p : m.getCollected()) {
+				u.put(p.getName(), p.getValue());
+			}
+
+			return u;
+		}
+
+		// Arguments did not match any usage pattern. Print usage and exit with
+		// error status.
+		throw new DocoptExitException(1, null, true);
+	}
+
+	/**
+	 * Parses {@code argv} based on command-line interface described by the
+	 * argument to the constructor.
+	 * <p>
+	 * This method will attempt to exit the invoking application if:
+	 * <ul>
+	 * <li>the arguments cannot be parsed
+	 * <li>the default {@code --help} behavior is invoked
+	 * <li>the default {@code --version} behavior is invoked
+	 * </ul>
+	 * <p>
+	 * In any of these cases, the parser will either terminate the JVM or throw
+	 * a {@link DocoptExitException}, depending on configuration via
+	 * {@link #withExit}.
+	 *
+	 * @param argv
+	 *            the command line arguments
+	 * @return A {@code Map}, where keys are names of command-line elements,
+	 *         such as "--verbose" and "&lt;path&gt;", and values are the parsed
+	 *         values of those elements.
+	 * @throws DocoptExitException
+	 *             if the application should exit and JVM termination has been
+	 *             disabled via {@link #withExit}
+	 */
+	public Map<String, Object> parse(final List<String> argv)
+			throws DocoptExitException {
+		try {
+			return doParse(argv);
+		}
+		catch (final DocoptExitException e) {
+			if (!exit) {
+				throw e;
+			}
+
+			@SuppressWarnings("resource")
+			final PrintStream ps = (e.getExitCode() == 0) ? out : err;
+
+			if (ps != null) {
+				final String message = e.getMessage();
+
+				if (message != null) {
+					ps.println(message);
+				}
+
+				if (e.getPrintUsage()) {
+					ps.println(usage);
+				}
+			}
+
+			System.exit(e.getExitCode());
+
+			// Not reachable.
+			throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Parses {@code argv} based on command-line interface described by the
+	 * argument to the constructor.
+	 * <p>
+	 * This method will attempt to exit the invoking application if:
+	 * <ul>
+	 * <li>the arguments cannot be parsed
+	 * <li>the default {@code --help} behavior is invoked
+	 * <li>the default {@code --version} behavior is invoked
+	 * </ul>
+	 * <p>
+	 * In any of these cases, the parser will either terminate the JVM or throw
+	 * a {@link DocoptExitException}, depending on configuration via
+	 * {@link #withExit}.
+	 *
+	 * @param argv
+	 *            the command line arguments
+	 * @return A {@code Map}, where keys are names of command-line elements,
+	 *         such as "--verbose" and "&lt;path&gt;", and values are the parsed
+	 *         values of those elements.
+	 * @throws DocoptExitException
+	 *             if the application should exit and JVM termination has been
+	 *             disabled via {@link #withExit}
+	 */
+	public Map<String, Object> parse(final String... argv) {
+		return parse(Arrays.asList(argv));
+	}
+
+	Docopt withStdOut(final PrintStream out) {
+		this.out = out;
+		return this;
+	}
+
+	Docopt withStdErr(final PrintStream err) {
+		this.err = err;
+		return this;
+	}
+}

--- a/Quark/src/main/java/org/docopt/DocoptExitException.java
+++ b/Quark/src/main/java/org/docopt/DocoptExitException.java
@@ -1,0 +1,40 @@
+package org.docopt;
+
+/**
+ * An exception thrown by {@link Docopt#parse} to indicate that the application
+ * should exit. This could be normal (e.g. default {@code --help} behavior) or
+ * abnormal (e.g. incorrect arguments).
+ */
+public final class DocoptExitException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int exitCode;
+
+	private final boolean printUsage;
+
+	DocoptExitException(final int exitCode, final String message,
+			final boolean printUsage) {
+		super(message);
+		this.exitCode = exitCode;
+		this.printUsage = printUsage;
+	}
+
+	DocoptExitException(final int exitCode) {
+		this(exitCode, null, false);
+	}
+
+	/**
+	 * Returns a numeric code indicating the cause of the exit. By convention, a
+	 * non-zero code indicates abnormal termination.
+	 *
+	 * @return the exit code
+	 */
+	public int getExitCode() {
+		return exitCode;
+	}
+
+	boolean getPrintUsage() {
+		return printUsage;
+	}
+}

--- a/Quark/src/main/java/org/docopt/DocoptLanguageError.java
+++ b/Quark/src/main/java/org/docopt/DocoptLanguageError.java
@@ -1,0 +1,13 @@
+package org.docopt;
+
+/**
+ * Error in construction of usage-message by developer.
+ */
+final class DocoptLanguageError extends Error {
+
+	private static final long serialVersionUID = 1L;
+
+	public DocoptLanguageError(final String message) {
+		super(message);
+	}
+}

--- a/Quark/src/main/java/org/docopt/Either.java
+++ b/Quark/src/main/java/org/docopt/Either.java
@@ -1,0 +1,49 @@
+package org.docopt;
+
+import static org.docopt.Python.list;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+final class Either extends BranchPattern {
+
+	public Either(final List<? extends Pattern> children) {
+		super(children);
+	}
+
+	@Override
+	protected MatchResult match(final List<LeafPattern> left,
+			List<LeafPattern> collected) {
+		if (collected == null) {
+			collected = list();
+		}
+
+		final List<MatchResult> outcomes = list();
+
+		for (final Pattern pattern : getChildren()) {
+			final MatchResult m = pattern.match(left, collected);
+			if (m.matched()) {
+				outcomes.add(m);
+			}
+		}
+
+		if (!outcomes.isEmpty()) {
+			// >>> return min(outcomes, key=lambda outcome: len(outcome[1]))
+			{
+				return Collections.min(outcomes, new Comparator<MatchResult>() {
+
+					@Override
+					public int compare(final MatchResult o1,
+							final MatchResult o2) {
+						final Integer s1 = Integer.valueOf(o1.getLeft().size());
+						final Integer s2 = Integer.valueOf(o2.getLeft().size());
+						return s1.compareTo(s2);
+					}
+				});
+			}
+		}
+
+		return new MatchResult(false, left, collected);
+	}
+}

--- a/Quark/src/main/java/org/docopt/LeafPattern.java
+++ b/Quark/src/main/java/org/docopt/LeafPattern.java
@@ -1,0 +1,213 @@
+package org.docopt;
+
+import static org.docopt.Python.bool;
+import static org.docopt.Python.in;
+import static org.docopt.Python.list;
+import static org.docopt.Python.plus;
+import static org.docopt.Python.repr;
+
+import java.util.List;
+
+/**
+ * Leaf/terminal node of a pattern tree.
+ */
+abstract class LeafPattern extends Pattern {
+
+	static class SingleMatchResult {
+
+		private final Integer position;
+
+		private final LeafPattern match;
+
+		public SingleMatchResult(final Integer position, final LeafPattern match) {
+			this.position = position;
+			this.match = match;
+		}
+
+		public Integer getPosition() {
+			return position;
+		}
+
+		public LeafPattern getMatch() {
+			return match;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%s(%d, %s)", getClass().getSimpleName(),
+					position, match);
+		}
+	}
+
+	private final String name;
+
+	private Object value;
+
+	public LeafPattern(final String name, final Object value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public LeafPattern(final String name) {
+		this(name, null);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s(%s, %s)", getClass().getSimpleName(),
+				repr(name), repr(value));
+	}
+
+	@Override
+	protected final List<Pattern> flat(final Class<?>... types) {
+		// >>> [self] if not types or type(self) in types else []
+		{
+			if (!bool(types) || in(getClass(), types)) {
+				return list((Pattern) this);
+			}
+
+			return list();
+		}
+	}
+
+	@Override
+	protected MatchResult match(final List<LeafPattern> left,
+			List<LeafPattern> collected) {
+		// >>> collected = [] if collected is None else collected
+		if (collected == null) {
+			collected = list();
+		}
+
+		Integer pos;
+		LeafPattern match;
+
+		// >>> pos, match = self.single_match(left)
+		{
+			final SingleMatchResult m = singleMatch(left);
+			pos = m.getPosition();
+			match = m.getMatch();
+		}
+
+		if (match == null) {
+			return new MatchResult(false, left, collected);
+		}
+
+		List<LeafPattern> left_;
+
+		// >>> left_ = left[:pos] + left[pos + 1:]
+		{
+			left_ = list();
+			left_.addAll(left.subList(0, pos));
+
+			if ((pos + 1) < left.size()) {
+				left_.addAll(left.subList(pos + 1, left.size()));
+			}
+		}
+
+		List<LeafPattern> sameName;
+
+		// >>> same_name = [a for a in collected if a.name == self.name]
+		{
+			sameName = list();
+
+			for (final LeafPattern a : collected) {
+				if (name.equals(a.getName())) {
+					sameName.add(a);
+				}
+			}
+		}
+
+		Object increment;
+
+		if ((value instanceof Integer) || (value instanceof List)) {
+			if (value instanceof Integer) {
+				increment = 1;
+			}
+			else {
+				final Object v = match.getValue();
+				increment = (v instanceof String) ? list(v) : v;
+			}
+
+			if (sameName.isEmpty()) {
+				match.setValue(increment);
+				return new MatchResult(true, left_,
+						plus(collected, list(match)));
+			}
+
+			// >>> same_name[0].value += increment
+			{
+				final LeafPattern p = sameName.get(0);
+				final Object v = p.getValue();
+
+				if (v instanceof Integer) {
+					final Integer a = (Integer) v;
+					final Integer b = (Integer) increment;
+					p.setValue(a + b);
+				}
+				else if (v instanceof List) {
+					@SuppressWarnings("unchecked")
+					final List<LeafPattern> a = (List<LeafPattern>) v;
+					@SuppressWarnings("unchecked")
+					final List<LeafPattern> b = (List<LeafPattern>) increment;
+					a.addAll(b);
+				}
+			}
+
+			// TODO: Should collected be copied to a new list?
+			return new MatchResult(true, left_, collected);
+		}
+
+		return new MatchResult(true, left_, plus(collected, list(match)));
+	}
+
+	protected abstract SingleMatchResult singleMatch(List<LeafPattern> left);
+
+	public String getName() {
+		return name;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public void setValue(final Object value) {
+		this.value = value;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final LeafPattern other = (LeafPattern) obj;
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		}
+		else if (!name.equals(other.name)) {
+			return false;
+		}
+		if (value == null) {
+			if (other.value != null) {
+				return false;
+			}
+		}
+		else if (!value.equals(other.value)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/Quark/src/main/java/org/docopt/OneOrMore.java
+++ b/Quark/src/main/java/org/docopt/OneOrMore.java
@@ -1,0 +1,51 @@
+package org.docopt;
+
+import static org.docopt.Python.list;
+
+import java.util.List;
+
+final class OneOrMore extends BranchPattern {
+
+	public OneOrMore(final List<? extends Pattern> children) {
+		super(children);
+	}
+
+	@Override
+	protected MatchResult match(final List<LeafPattern> left,
+			List<LeafPattern> collected) {
+		assert getChildren().size() == 1;
+
+		if (collected == null) {
+			collected = list();
+		}
+
+		List<LeafPattern> l = left;
+		List<LeafPattern> c = collected;
+		List<LeafPattern> l_ = null;
+		final boolean matched = true;
+		int times = 0;
+
+		while (matched) {
+			final MatchResult m = getChildren().get(0).match(l, c);
+
+			l = m.getLeft();
+			c = m.getCollected();
+
+			if (m.matched()) {
+				times++;
+			}
+
+			if ((l == null) ? (l_ == null) : l.equals(l_)) {
+				break;
+			}
+
+			l_ = l;
+		}
+
+		if (times >= 1) {
+			return new MatchResult(true, l, c);
+		}
+
+		return new MatchResult(false, left, collected);
+	}
+}

--- a/Quark/src/main/java/org/docopt/Option.java
+++ b/Quark/src/main/java/org/docopt/Option.java
@@ -1,0 +1,161 @@
+package org.docopt;
+
+import static org.docopt.Python.bool;
+import static org.docopt.Python.partition;
+import static org.docopt.Python.repr;
+import static org.docopt.Python.split;
+
+import java.util.List;
+
+import org.docopt.Python.Re;
+
+final class Option extends LeafPattern {
+
+	private final String $short;
+
+	private final String $long;
+
+	private final int argCount;
+
+	// >>> def __init__(self, short=None, long=None, argcount=0, value=False)
+	public Option(final String $short, final String $long, final int argCount,
+			final Object value) {
+		super(
+		// >>> @property
+		// >>> def name(self):
+		// >>> return self.long or self.short
+				($long != null) ? $long : $short,
+				// >>> self.value = None if value is False and argcount else
+				// value
+				(Boolean.FALSE.equals(value) && argCount != 0) ? null : value);
+
+		assert argCount == 0 || argCount == 1;
+
+		this.$short = $short;
+		this.$long = $long;
+		this.argCount = argCount;
+	}
+
+	public Option(final String $short, final String $long, final int argCount) {
+		this($short, $long, argCount, false);
+	}
+
+	public Option(final String $short, final String $long) {
+		this($short, $long, 0);
+	}
+
+	public static Option parse(final String optionDescription) {
+		String $short = null;
+		String $long = null;
+		int argCount = 0;
+		Object value = false;
+
+		String options;
+		String description;
+
+		// >>> options, _, description = option_description.strip().partition('
+		// ')
+		{
+			final String[] a = partition(optionDescription.trim(), "  ");
+			options = a[0];
+			description = a[2];
+		}
+
+		options = options.replaceAll(",", " ").replaceAll("=", " ");
+
+		for (final String s : split(options)) {
+			if (s.startsWith("--")) {
+				$long = s;
+			}
+			else if (s.startsWith("-")) {
+				$short = s;
+			}
+			else {
+				argCount = 1;
+			}
+		}
+
+		if (argCount != 0) {
+			final List<String> matched = Re.findAll("\\[default: (.*)\\]",
+					description, Re.IGNORECASE);
+			value = bool(matched) ? matched.get(0) : null;
+		}
+
+		return new Option($short, $long, argCount, value);
+	}
+
+	@Override
+	protected SingleMatchResult singleMatch(final List<LeafPattern> left) {
+		for (int n = 0; n < left.size(); n++) {
+			final LeafPattern pattern = left.get(n);
+
+			if (getName().equals(pattern.getName())) {
+				return new SingleMatchResult(n, pattern);
+			}
+		}
+
+		return new SingleMatchResult(null, null);
+	}
+
+	public String getShort() {
+		return $short;
+	}
+
+	public String getLong() {
+		return $long;
+	}
+
+	public int getArgCount() {
+		return argCount;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (($long == null) ? 0 : $long.hashCode());
+		result = prime * result + (($short == null) ? 0 : $short.hashCode());
+		result = prime * result + argCount;
+		return result;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final Option other = (Option) obj;
+		if ($long == null) {
+			if (other.$long != null) {
+				return false;
+			}
+		}
+		else if (!$long.equals(other.$long)) {
+			return false;
+		}
+		if ($short == null) {
+			if (other.$short != null) {
+				return false;
+			}
+		}
+		else if (!$short.equals(other.$short)) {
+			return false;
+		}
+		if (argCount != other.argCount) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s(%s, %s, %s, %s)", getClass().getSimpleName(),
+				repr($short), repr($long), repr(argCount), repr(getValue()));
+	}
+}

--- a/Quark/src/main/java/org/docopt/Optional.java
+++ b/Quark/src/main/java/org/docopt/Optional.java
@@ -1,0 +1,28 @@
+package org.docopt;
+
+import java.util.List;
+
+import static org.docopt.Python.list;
+
+class Optional extends BranchPattern {
+
+	public Optional(final List<? extends Pattern> children) {
+		super(children);
+	}
+
+	@Override
+	protected MatchResult match(List<LeafPattern> left,
+			List<LeafPattern> collected) {
+		if (collected == null) {
+			collected = list();
+		}
+
+		for (final Pattern pattern : getChildren()) {
+			final MatchResult u = pattern.match(left, collected);
+			left = u.getLeft();
+			collected = u.getCollected();
+		}
+
+		return new MatchResult(true, left, collected);
+	}
+}

--- a/Quark/src/main/java/org/docopt/OptionsShortcut.java
+++ b/Quark/src/main/java/org/docopt/OptionsShortcut.java
@@ -1,0 +1,13 @@
+package org.docopt;
+
+import java.util.Collections;
+
+/**
+ * Marker/placeholder for [options] shortcut.
+ */
+final class OptionsShortcut extends Optional {
+
+	public OptionsShortcut() {
+		super(Collections.<Pattern> emptyList());
+	}
+}

--- a/Quark/src/main/java/org/docopt/Pattern.java
+++ b/Quark/src/main/java/org/docopt/Pattern.java
@@ -1,0 +1,212 @@
+package org.docopt;
+
+import static org.docopt.Python.count;
+import static org.docopt.Python.list;
+import static org.docopt.Python.set;
+import static org.docopt.Python.split;
+
+import java.util.Arrays;
+import java.util.List;
+
+abstract class Pattern {
+
+	static class MatchResult {
+
+		private final boolean match;
+
+		private final List<LeafPattern> left;
+
+		private final List<LeafPattern> collected;
+
+		public MatchResult(final boolean match, final List<LeafPattern> left,
+				final List<LeafPattern> collected) {
+			this.match = match;
+			this.left = left;
+			this.collected = collected;
+		}
+
+		public boolean matched() {
+			return match;
+		}
+
+		public List<LeafPattern> getLeft() {
+			return left;
+		}
+
+		public List<LeafPattern> getCollected() {
+			return collected;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static final List<Class<? extends BranchPattern>> PARENTS = Arrays
+			.asList(Required.class, Optional.class, OptionsShortcut.class,
+					Either.class, OneOrMore.class);
+
+	/**
+	 * Expand pattern into an (almost) equivalent one, but with single Either.
+	 * 
+	 * Example: ((-a | -b) (-c | -d)) => (-a -c | -a -d | -b -c | -b -d) Quirks:
+	 * [-a] => (-a), (-a...) => (-a -a)
+	 */
+	private static Either transform(final Pattern pattern) {
+		final List<List<Pattern>> result = list();
+		List<List<Pattern>> groups;
+
+		// >>> groups = [[pattern]]
+		{
+			// Can't use "groups = list(list(pattern))" since the argument is
+			// iterable.
+			groups = list();
+			groups.add(list(pattern));
+		}
+
+		while (!groups.isEmpty()) {
+			final List<Pattern> children = groups.remove(0);
+
+			BranchPattern child = null;
+
+			// "If any parent type is the same type as the type of any child, select the first child that is of a type in parents."
+			// >>> if any(t in map(type, children) for t in parents):
+			// >>> child = [c for c in children if type(c) in parents][0]
+			// TODO: I think that the "if" clause is redundant; instead, we just
+			// try to get the child directly.
+			for (final Pattern c : children) {
+				if (PARENTS.contains(c.getClass())) {
+					child = (BranchPattern) c;
+					break;
+				}
+			}
+
+			// See above for changes from python implementation.
+			if (child != null) {
+				children.remove(child);
+
+				if (child.getClass() == Either.class) {
+					for (final Pattern c : child.getChildren()) {
+						// >>> groups.append([c] + children)
+						final List<Pattern> group = list(c);
+						group.addAll(children);
+						groups.add(group);
+					}
+				}
+				else if (child.getClass() == OneOrMore.class) {
+					// >>> groups.append(child.children * 2 + children)
+					final List<Pattern> group = list(child.getChildren());
+					group.addAll(child.getChildren());
+					group.addAll(children);
+					groups.add(group);
+				}
+				else {
+					// >>> groups.append(child.children + children)
+					final List<Pattern> group = list(child.getChildren());
+					group.addAll(children);
+					groups.add(group);
+				}
+			}
+			else {
+				result.add(children);
+			}
+		}
+
+		// >>> return Either(*[Required(*e) for e in result])
+		{
+			final List<Required> required = list();
+
+			for (final List<Pattern> e : result) {
+				required.add(new Required(e));
+			}
+
+			return new Either(required);
+		}
+	}
+
+	public Pattern fix() {
+		fixIdentities(null);
+		fixRepeatingArguments();
+		return this;
+	}
+
+	/**
+	 * Make pattern-tree tips point to same object if they are equal.
+	 */
+	private void fixIdentities(List<Pattern> uniq) {
+		// >>> if not hasattr(self, 'children')
+		if (!(this instanceof BranchPattern)) {
+			return;
+		}
+
+		if (uniq == null) {
+			uniq = list(set(flat()));
+		}
+
+		final List<Pattern> children = ((BranchPattern) this).getChildren();
+
+		for (int i = 0; i < children.size(); i++) {
+			final Pattern child = children.get(i);
+
+			if (!(child instanceof BranchPattern)) {
+				assert uniq.contains(child);
+				children.set(i, uniq.get(uniq.indexOf(child)));
+			}
+			else {
+				child.fixIdentities(uniq);
+			}
+		}
+	}
+
+	/**
+	 * Fix elements that should accumulate/increment values.
+	 */
+	private void fixRepeatingArguments() {
+		List<List<Pattern>> either;
+
+		// >>> either = [list(child.children) for child in
+		// transform(self).children]
+		{
+			either = list();
+
+			for (final Pattern child : transform(this).getChildren()) {
+				either.add(list(((Required) child).getChildren()));
+			}
+		}
+
+		for (final List<Pattern> $case : either) {
+			// >>> for e in [child for child in case if case.count(child) > 1]
+			for (final Pattern child : $case) { // ^^^
+				if (count($case, child) > 1) { // ^^^
+					final LeafPattern e = (LeafPattern) child; // ^^^
+
+					if ((e.getClass() == Argument.class)
+							|| ((e.getClass() == Option.class) && ((Option) e)
+									.getArgCount() != 0)) {
+						if (e.getValue() == null) {
+							e.setValue(list());
+						}
+						else if (!(e.getValue() instanceof List)) {
+							e.setValue(split(e.getValue().toString()));
+						}
+					}
+
+					if ((e.getClass() == Command.class)
+							|| ((e.getClass() == Option.class) && ((Option) e)
+									.getArgCount() == 0)) {
+						e.setValue(0);
+					}
+				}
+			}
+		}
+	}
+
+	protected abstract List<Pattern> flat(Class<?>... types);
+
+	protected abstract MatchResult match(List<LeafPattern> left,
+			List<LeafPattern> collected);
+
+	protected MatchResult match(final List<LeafPattern> left) {
+		return match(left, null);
+	}
+
+	@Override
+	public abstract boolean equals(Object obj);
+}

--- a/Quark/src/main/java/org/docopt/Python.java
+++ b/Quark/src/main/java/org/docopt/Python.java
@@ -1,0 +1,360 @@
+package org.docopt;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class Python {
+
+	static final class Re {
+
+		public static final int IGNORECASE = Pattern.CASE_INSENSITIVE;
+
+		public static final int MULTILINE = Pattern.MULTILINE
+				| Pattern.UNIX_LINES;
+
+		public static List<String> findAll(final String pattern,
+				final String string, final int flags) {
+			return findAll(Pattern.compile(pattern, flags), string);
+		}
+
+		public static List<String> findAll(final Pattern pattern,
+				final String string) {
+			final Matcher matcher = pattern.matcher(string);
+
+			final List<String> result = list();
+
+			while (matcher.find()) {
+				if (matcher.groupCount() == 0) {
+					result.add(matcher.group());
+				}
+				else {
+					for (int i = 0; i < matcher.groupCount(); i++) {
+						final String match = matcher.group(i + 1);
+
+						if (match != null) {
+							result.add(match);
+						}
+					}
+				}
+			}
+
+			return result;
+		}
+
+		/**
+		 * Determines if {@code pattern} contains at least one capturing group.
+		 */
+		private static boolean hasGrouping(final String pattern) {
+			int i = -1;
+
+			// Find the potential beginning of a group by looking for a left
+			// parenthesis character.
+			while ((i = pattern.indexOf('(', i + 1)) != -1) {
+				int c = 0;
+
+				// Count the number of escape characters immediately preceding
+				// the
+				// left parenthesis character.
+				for (int j = i - 1; j > -1; j--) {
+					if (pattern.charAt(j) != '\\') {
+						break;
+					}
+
+					c++;
+				}
+
+				// If there is an even number of consecutive escape characters,
+				// the character is not escaped and begins a group.
+				if (c % 2 == 0) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public static List<String> split(final String pattern,
+				final String string) {
+			if (!hasGrouping(pattern)) {
+				return list(string.split(pattern));
+			}
+
+			final Matcher matcher = Pattern.compile(pattern, 0).matcher(string);
+
+			final List<String> matches = list();
+
+			int start = 0;
+
+			while (matcher.find()) {
+				matches.add(string.substring(start, matcher.start()));
+
+				for (int i = 0; i < matcher.groupCount(); i++) {
+					matches.add(matcher.group(i + 1));
+				}
+
+				start = matcher.end();
+			}
+
+			matches.add(string.substring(start));
+
+			return matches;
+		}
+
+		public static String sub(final String pattern, final String repl,
+				final String string) {
+			return Pattern.compile(pattern, 0).matcher(string).replaceAll(repl);
+		}
+
+		private Re() {
+			// Prevent instantiation.
+		}
+	}
+
+	/**
+	 * http://docs.python.org/2/library/#truth-value-testing
+	 */
+	public static boolean bool(final Object o) {
+		// None
+		if (o == null) {
+			return false;
+		}
+
+		// False
+		if (o instanceof Boolean) {
+			return ((Boolean) o).booleanValue();
+		}
+
+		// zero of any numeric type, for example, 0, 0L, 0.0, 0j
+		if (o instanceof Number) {
+			if (o instanceof Integer) {
+				return !((Integer) o).equals(0);
+			}
+
+			if (o instanceof Long) {
+				return !((Long) o).equals(0L);
+			}
+
+			if (o instanceof Double) {
+				return !((Double) o).equals(0.0);
+			}
+
+			if (o instanceof Float) {
+				return !((Float) o).equals(0.0F);
+			}
+
+			if (o instanceof Byte) {
+				return !((Byte) o).equals((byte) 0);
+			}
+
+			if (o instanceof Short) {
+				return !((Short) o).equals((short) 0);
+			}
+
+			if (o instanceof AtomicInteger) {
+				return bool(((AtomicInteger) o).get());
+			}
+
+			if (o instanceof AtomicLong) {
+				return bool(((AtomicLong) o).get());
+			}
+
+			if (o instanceof BigDecimal) {
+				return !BigDecimal.ZERO.equals(o);
+			}
+
+			if (o instanceof BigInteger) {
+				return !BigInteger.ZERO.equals(o);
+			}
+
+			throw new IllegalArgumentException("unknown numeric type: "
+					+ o.getClass());
+		}
+
+		// any empty sequence, for example, '', (), []
+		{
+			if (o instanceof String) {
+				return !"".equals(o);
+			}
+
+			if (o instanceof Object[]) {
+				return ((Object[]) o).length != 0;
+			}
+
+			if (o instanceof Collection) {
+				return !((Collection<?>) o).isEmpty();
+			}
+		}
+
+		// any empty mapping, for example, {}
+		if (o instanceof Map) {
+			return !((Map<?, ?>) o).isEmpty();
+		}
+
+		// All other values are considered true - so objects of many types are
+		// always true.
+		return true;
+	}
+
+	public static <T> boolean in(final T left, final T... right) {
+		for (final Object o : right) {
+			if (left != null) {
+				if (left.equals(o)) {
+					return true;
+				}
+			}
+			else {
+				if (o == null) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	// Plus operator
+	public static <T> List<T> plus(final List<T> a, final List<T> b) {
+		final List<T> c = new ArrayList<T>(a.size() + b.size());
+
+		c.addAll(a);
+		c.addAll(b);
+
+		return c;
+	}
+
+	public static String repr(final Object o) {
+		if (o == null) {
+			return "null";
+		}
+
+		if (o instanceof String) {
+			return "\"" + o + "\"";
+		}
+
+		if (o instanceof Object[]) {
+			return Arrays.toString((Object[]) o);
+		}
+
+		return o.toString();
+	}
+
+	public static <T> List<T> list(final Iterable<? extends T> elements) {
+		final List<T> list = list();
+
+		for (final T element : elements) {
+			list.add(element);
+		}
+
+		return list;
+	}
+
+	public static <T> List<T> list(final T[] elements) {
+		final List<T> list = list();
+		for (final T element : elements) {
+			list.add(element);
+		}
+		return list;
+	}
+
+	public static <T> List<T> list(final T element) {
+		final List<T> list = list();
+		list.add(element);
+		return list;
+	}
+
+	public static <T> List<T> list() {
+		return new ArrayList<T>();
+	}
+
+	public static <T> int count(final List<T> self, final T obj) {
+		int count = 0;
+
+		for (final T element : self) {
+			if (element.equals(obj)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	public static <T> Set<T> set(final Iterable<T> elements) {
+		final Set<T> set = new HashSet<T>();
+
+		for (final T element : elements) {
+			set.add(element);
+		}
+
+		return set;
+	}
+
+	public static String join(final String self, final Iterable<?> iterable) {
+		final Iterator<?> i = iterable.iterator();
+
+		if (!i.hasNext()) {
+			return "";
+		}
+
+		final StringBuilder sb = new StringBuilder();
+
+		while (i.hasNext()) {
+			sb.append(i.next());
+			sb.append(self);
+		}
+
+		sb.setLength(sb.length() - self.length());
+
+		return sb.toString();
+	}
+
+	public static String[] partition(final String self, final String sep) {
+		final int i = self.indexOf(sep);
+
+		if (i == -1) {
+			return new String[] { self, "", "" };
+		}
+
+		// Always <= s.length
+		final int j = i + sep.length();
+
+		return new String[] { self.substring(0, i), sep,
+				(j < self.length()) ? self.substring(j) : "" };
+	}
+
+	public static boolean isUpper(final String self) {
+		boolean result = false;
+
+		for (final char c : self.toCharArray()) {
+			if (Character.isLetter(c)) {
+				if (Character.isUpperCase(c)) {
+					result = true;
+				}
+				else {
+					return false;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static List<String> split(final String self) {
+		return list(self.trim().split("\\s+"));
+	}
+
+	private Python() {
+		// Prevent instantiation.
+	}
+}

--- a/Quark/src/main/java/org/docopt/Required.java
+++ b/Quark/src/main/java/org/docopt/Required.java
@@ -1,0 +1,36 @@
+package org.docopt;
+
+import static org.docopt.Python.list;
+
+import java.util.List;
+
+final class Required extends BranchPattern {
+
+	public Required(final List<? extends Pattern> children) {
+		super(children);
+	}
+
+	@Override
+	protected MatchResult match(final List<LeafPattern> left,
+			List<LeafPattern> collected) {
+		if (collected == null) {
+			collected = list();
+		}
+
+		List<LeafPattern> l = left;
+		List<LeafPattern> c = collected;
+
+		for (final Pattern pattern : getChildren()) {
+			final MatchResult m = pattern.match(l, c);
+
+			l = m.getLeft();
+			c = m.getCollected();
+
+			if (!m.matched()) {
+				return new MatchResult(false, left, collected);
+			}
+		}
+
+		return new MatchResult(true, l, c);
+	}
+}

--- a/Quark/src/main/java/org/docopt/Tokens.java
+++ b/Quark/src/main/java/org/docopt/Tokens.java
@@ -1,0 +1,82 @@
+package org.docopt;
+
+import static org.docopt.Python.bool;
+import static org.docopt.Python.list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.docopt.Python.Re;
+
+final class Tokens extends ArrayList<String> {
+
+	private static final long serialVersionUID = 1L;
+
+	public static Tokens withExitException(final List<String> source) {
+		return new Tokens(source, DocoptExitException.class);
+	}
+
+	public static Tokens withLanguageError(final List<String> source) {
+		return new Tokens(source, DocoptLanguageError.class);
+	}
+
+	private final Class<? extends Throwable> error;
+
+	public Tokens(final List<String> source,
+			final Class<? extends Throwable> error) {
+		// >>> self += source.split() if hasattr(source, 'split') else source
+		// In this implementation, source is always a list of strings, so no
+		// need to split.
+		addAll(source);
+		this.error = error;
+	}
+
+	public static Tokens fromPattern(String source) {
+		source = Re.sub("([\\[\\]\\(\\)\\|]|\\.\\.\\.)", " $1 ", source);
+
+		List<String> $source;
+
+		// >>> source = [s for s in re.split('\s+|(\S*<.*?>)', source) if s]
+		{
+			$source = list();
+
+			for (final String s : Re.split("\\s+|(\\S*<.*?>)", source)) {
+				if (bool(s)) {
+					$source.add(s);
+				}
+			}
+		}
+
+		return Tokens.withLanguageError($source);
+	}
+
+	public String move() {
+		final String result = isEmpty() ? null : remove(0);
+		return result;
+	}
+
+	public String current() {
+		final String result = isEmpty() ? null : get(0);
+		return result;
+	}
+
+	public Class<? extends Throwable> getError() {
+		return error;
+	}
+
+	public IllegalStateException error(final String format,
+			final Object... args) {
+		final String message = String.format(format, args);
+
+		if (error == DocoptLanguageError.class) {
+			throw new DocoptLanguageError(message);
+		}
+
+		if (error == DocoptExitException.class) {
+			throw new DocoptExitException(1, message, true);
+		}
+
+		return new IllegalStateException("Unexpected exception: "
+				+ error.getClass().getName());
+	}
+}

--- a/Quark/src/main/java/xorTroll/goldleaf/quark/CommandLineParser.java
+++ b/Quark/src/main/java/xorTroll/goldleaf/quark/CommandLineParser.java
@@ -1,0 +1,42 @@
+
+/*
+
+    Goldleaf - Multipurpose homebrew tool for Nintendo Switch
+    Copyright (C) 2018-2019  XorTroll
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+package xorTroll.goldleaf.quark;
+
+import java.util.Map;
+import org.docopt.Docopt;
+
+public class CommandLineParser {
+    private static final String DOCSTRING = "Quark.\n"
+            + "\n"
+            + "Usage:\n"
+            + "  quark.jar [-h] [--config-file=<config-file>]\n"
+            + "\n"
+            + "Options:\n"
+            + "  -h  Show this help message.\n"
+            + "  --config-file=<config-file>  Configuration file to use. [default: quark-config.cfg]\n";
+    
+    public static void parseArguments(String[] args) {
+        Docopt parser = new Docopt(DOCSTRING);
+        Map<String,Object> parsedArgs = parser.parse(args);
+        String configFile = (String) parsedArgs.get("--config-file");
+    }
+}

--- a/Quark/src/main/java/xorTroll/goldleaf/quark/CommandLineParser.java
+++ b/Quark/src/main/java/xorTroll/goldleaf/quark/CommandLineParser.java
@@ -38,5 +38,6 @@ public class CommandLineParser {
         Docopt parser = new Docopt(DOCSTRING);
         Map<String,Object> parsedArgs = parser.parse(args);
         String configFile = (String) parsedArgs.get("--config-file");
+        Config.ConfigPath = configFile;
     }
 }

--- a/Quark/src/main/java/xorTroll/goldleaf/quark/Config.java
+++ b/Quark/src/main/java/xorTroll/goldleaf/quark/Config.java
@@ -29,7 +29,7 @@ import java.util.Properties;
 
 public class Config
 {
-    public static final String ConfigPath = "quark-config.cfg";
+    public static String ConfigPath = "quark-config.cfg";
     public Properties data = new Properties();
     private File cfg;
 

--- a/Quark/src/main/java/xorTroll/goldleaf/quark/Main.java
+++ b/Quark/src/main/java/xorTroll/goldleaf/quark/Main.java
@@ -27,6 +27,7 @@ public class Main
 {
     public static void main(String[] args)
     {
+        CommandLineParser.parseArguments(args);
         MainApplication.main(args);
     }
 }


### PR DESCRIPTION
If merged, this PR closes #490 .

Implements the feature request as I described in #490. Notable changes mentioned below.

## Notable changes

- ConfigPath in Config.java is no longer final.
- New class called CommandLineParser.
- CommandLineParser is called before the GUI is started.
- Inclusion of [docopt.java](https://github.com/docopt/docopt.java). [license: MIT. docopt.java code was not modified].
- New launch flag called `--config-file`. If specified, changes the config file Quark uses. Defaults to `quark-config.cfg` if not specified, so existing setups should not break.
- New flag called `-h`. This is a bundled flag from docopt.java that simply prints the docstring. This is also done if wrong commandline flags are specified.