### PR TITLE
Made this work without the need for Oracle JDK

### DIFF
--- a/Quark/pom.xml
+++ b/Quark/pom.xml
@@ -22,7 +22,6 @@
     </repositories>
 
     <dependencies>
-  
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>

--- a/Quark/src/main/java/xorTroll/goldleaf/quark/fs/FileSystem.java
+++ b/Quark/src/main/java/xorTroll/goldleaf/quark/fs/FileSystem.java
@@ -29,15 +29,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Vector;
 
-import com.sun.javafx.PlatformUtil;
-
 public class FileSystem
 {
     public static final String HomeDrive = "Home";
-
-    public static boolean isWindows()
-    {
-        return PlatformUtil.isWindows();
+   
+    public static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     public static Vector<String> listDrives()


### PR DESCRIPTION
Removed the need for ALL linux users to download the crappy Oracle JDK. Quark now works with any JRE you want.

Please refrain from using any "com.sun.***" package in the future, as they're oracle-specific and usually really outdated.