### PR TITLE
Remove unnecessary "extra" recursion when deleting directories

### DIFF
--- a/Goldleaf/Include/fs/fs_Explorer.hpp
+++ b/Goldleaf/Include/fs/fs_Explorer.hpp
@@ -61,7 +61,6 @@ namespace fs
             std::vector<String> ReadFileLines(String Path, u32 LineOffset, u32 LineCount);
             std::vector<String> ReadFileFormatHex(String Path, u32 LineOffset, u32 LineCount);
             u64 GetDirectorySize(String Path);
-            void DeleteDirectory(String Path);
 
             virtual std::vector<String> GetDirectories(String Path) = 0;
             virtual std::vector<String> GetFiles(String Path) = 0;
@@ -73,7 +72,7 @@ namespace fs
             virtual void RenameFile(String Path, String NewName) = 0;
             virtual void RenameDirectory(String Path, String NewName) = 0;
             virtual void DeleteFile(String Path) = 0;
-            virtual void DeleteDirectorySingle(String Path) = 0;
+            virtual void DeleteDirectory(String Path) = 0;
             
             virtual void StartFile(String path, FileMode mode) = 0;
             virtual u64 ReadFileBlock(String Path, u64 Offset, u64 Size, u8 *Out) = 0;

--- a/Goldleaf/Include/fs/fs_RemotePCExplorer.hpp
+++ b/Goldleaf/Include/fs/fs_RemotePCExplorer.hpp
@@ -38,7 +38,7 @@ namespace fs
             virtual void RenameFile(String Path, String NewName) override;
             virtual void RenameDirectory(String Path, String NewName) override;
             virtual void DeleteFile(String Path) override;
-            virtual void DeleteDirectorySingle(String Path) override;
+            virtual void DeleteDirectory(String Path) override;
             virtual void StartFile(String path, FileMode mode) override;
             virtual u64 ReadFileBlock(String Path, u64 Offset, u64 Size, u8 *Out) override;
             virtual u64 WriteFileBlock(String Path, u8 *Data, u64 Size) override;

--- a/Goldleaf/Include/fs/fs_StdExplorer.hpp
+++ b/Goldleaf/Include/fs/fs_StdExplorer.hpp
@@ -41,7 +41,7 @@ namespace fs
             virtual void RenameFile(String Path, String NewName) override;
             virtual void RenameDirectory(String Path, String NewName) override;
             virtual void DeleteFile(String Path) override;
-            virtual void DeleteDirectorySingle(String Path) override;
+            virtual void DeleteDirectory(String Path) override;
             virtual void StartFile(String path, FileMode mode) override;
             virtual u64 ReadFileBlock(String Path, u64 Offset, u64 Size, u8 *Out) override;
             virtual u64 WriteFileBlock(String Path, u8 *Data, u64 Size) override;

--- a/Goldleaf/Source/fs/fs_Explorer.cpp
+++ b/Goldleaf/Source/fs/fs_Explorer.cpp
@@ -338,22 +338,4 @@ namespace fs
         for(auto &file: files) sz += this->GetFileSize(path + "/" + file);
         return sz;
     }
-
-    void Explorer::DeleteDirectory(String Path)
-    {
-        String path = this->MakeFull(Path);
-        auto dirs = this->GetDirectories(path);
-        for(auto &dir: dirs)
-        {
-            String pd = path + "/" + dir;
-            this->DeleteDirectory(pd);
-        }
-        auto files = this->GetFiles(path);
-        for(auto &file: files)
-        {
-            String pd = path + "/" + file;
-            this->DeleteFile(pd);
-        }
-        this->DeleteDirectorySingle(path);
-    }
 }

--- a/Goldleaf/Source/fs/fs_RemotePCExplorer.cpp
+++ b/Goldleaf/Source/fs/fs_RemotePCExplorer.cpp
@@ -135,7 +135,7 @@ namespace fs
         usb::ProcessCommand<usb::CommandId::Delete>(usb::In32(1), usb::InString(path));
     }
 
-    void RemotePCExplorer::DeleteDirectorySingle(String Path)
+    void RemotePCExplorer::DeleteDirectory(String Path)
     {
         String path = this->MakeFull(Path);
         usb::ProcessCommand<usb::CommandId::Delete>(usb::In32(2), usb::InString(path));

--- a/Goldleaf/Source/fs/fs_StdExplorer.cpp
+++ b/Goldleaf/Source/fs/fs_StdExplorer.cpp
@@ -135,7 +135,7 @@ namespace fs
         this->commit_fn();
     }
 
-    void StdExplorer::DeleteDirectorySingle(String Path)
+    void StdExplorer::DeleteDirectory(String Path)
     {
         String path = this->MakeFull(Path);
         fsdevDeleteDirectoryRecursively(path.AsUTF8().c_str());


### PR DESCRIPTION
When deleting directories locally, `fsdevDeleteDirectoryRecursively` already deletes recursively and when deleting via USB, (in Quark) `FileSystem.deletePath` also does it.

This reduces the ammount of USB commands needed to delete a directory from the number of files in the directory to 1, also making it faster for large (as in lots of small files) dirs.