### PR TITLE
Fix table of contents (Quark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 1. [Features](#features)
 2. [Disclaimer](#disclaimer)
-3. [Quark and remote PC](#quark-and-remote-pc)
+3. [Quark and remote PC](#quark-and-remote-browsing)
 4. [Settings](#settings)
 5. [Known bugs](#known-bugs)
 6. [Building](#building)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 1. [Features](#features)
 2. [Disclaimer](#disclaimer)
-3. [Quark and remote PC](#quark-and-remote-browsing)
+3. [Quark and remote browsing](#quark-and-remote-browsing)
 4. [Settings](#settings)
 5. [Known bugs](#known-bugs)
 6. [Building](#building)


### PR DESCRIPTION
3. In the table of contents linked to a header that no longer exists.

Changed this over to the correct one :)