### PR TITLE
Quark - udev rule compatibility

### DIFF
--- a/Quark.md
+++ b/Quark.md
@@ -38,7 +38,7 @@ Install OpenJDK 11 (or higher) in the terminal:
 
 - Finally, run ```sudo apt-get install openjdk-11-jdk``` (if you just want the JRE, install `openjdk-11-jre` instead)
 
-- Create the file ```/etc/udev/rules.d/99-switch.rules``` with the following contents: ```SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", GROUP="plugdev"```
+- Create the file ```/etc/udev/rules.d/99-switch.rules``` with the following contents: ```SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", TAG+="uaccess", TAG+="udev-acl"```
 
 - Reload udev rules with: ```sudo udevadm control --reload-rules```
 


### PR DESCRIPTION
Many distributions do not have the 'plugdev' group by default. A solution for this issue is discussed here: https://wiki.archlinux.org/title/Talk:Udev#Use_of_.27uaccess.27_instead_of_GROUP_and_MODE.3F

I've confirmed this to work on Arch Linux.