### PR TITLE
docs: update brew install command for Quark

### DIFF
--- a/Quark.md
+++ b/Quark.md
@@ -52,7 +52,7 @@ Install OpenJDK 11 (or higher) in the terminal:
 
 - Run ```brew tap AdoptOpenJDK/openjdk```
 
-- Run ```brew cask install adoptopenjdk11```
+- Run ```brew install adoptopenjdk11 --cask```
 
 - Finally, run ```java -version``` to check the JDK version
 


### PR DESCRIPTION
Currently getting this error when following the Quark setup guide for Mac:
```
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```