### PR TITLE
Use system config directory for Quark's config file

### DIFF
--- a/Quark/src/main/java/xortroll/goldleaf/quark/Config.java
+++ b/Quark/src/main/java/xortroll/goldleaf/quark/Config.java
@@ -24,31 +24,34 @@ package xortroll.goldleaf.quark;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
 public class Config {
-    public static String ConfigPathName = "quark-config.cfg";
-    public static String ConfigPath = ConfigPathName;
+    public static Path ConfigPath;
     private Properties inner_cfg;
     private File cfg_file;
 
-    static {
-        try {
-            ConfigPath = Paths.get(new File(Config.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getPath(), ConfigPathName).toString();
-        }
-        catch(Exception e) {
-            ConfigPath = ConfigPathName;
-        }
-    }
-
     public Config() throws Exception {
+        if(ConfigPath == null) {
+            String configHome = System.getenv("XDG_CONFIG_HOME");
+            if (configHome == null || configHome.trim().length() == 0) {
+                configHome = System.getProperty("user.home") + File.separator + ".config";
+            }
+            Path quarkConfigDirPath = Paths.get(configHome, "quark");
+            if (Files.notExists(quarkConfigDirPath)) {
+                Files.createDirectories(quarkConfigDirPath);
+            }
+            ConfigPath = quarkConfigDirPath.resolve("quark-config.cfg");
+        }
         this.inner_cfg = new Properties();
         reloadConfigFile();
     }
 
     public void reloadConfigFile() throws Exception {
-        this.cfg_file = Paths.get(ConfigPath).toFile();
+        this.cfg_file = ConfigPath.toFile();
         if(this.cfg_file.isFile()) {
             this.inner_cfg.load(new FileInputStream(this.cfg_file));
         }

--- a/Quark/src/main/java/xortroll/goldleaf/quark/Main.java
+++ b/Quark/src/main/java/xortroll/goldleaf/quark/Main.java
@@ -21,6 +21,7 @@
 
 package xortroll.goldleaf.quark;
 
+import java.nio.file.Paths;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -38,7 +39,7 @@ public class Main {
         try {
             CommandLine cmd = parser.parse(options, args);
             if(cmd.hasOption(ConfigFileOption)) {
-                Config.ConfigPath = cmd.getOptionValue(ConfigFileOption);
+                Config.ConfigPath = Paths.get(cmd.getOptionValue(ConfigFileOption));
             }
         }
         catch(Exception e) {


### PR DESCRIPTION
This PR will change Quark's config file's default location.

Reason for PR: my Quark `.jar` file is in a write-protected directory, so it can't create the config file.

(Trying to package Quark for `nixpkgs`, where every package is write-protected) (see https://github.com/NixOS/nixpkgs/pull/251015)

Previously, the program would place the config next to Quark's `.jar` file, or if it couldn't find it, it just used the working directory (I think).

After this PR, the `quark-config.cfg` file will be created in `$XDG_CONFIG_HOME/quark`, or if the env-var is not set, it will just use `$HOME/.config/quark`.
(`$XDG_CONFIG_HOME` is usually just `$HOME/.config`)

It should work on Windows as well, placing it `C:/Users/CurrentUser/.config/quark`.

Specifying the config file via `-cfgfile` should still work.

---

This will be a small semi-breaking change, but I doubt people can't move or re-add their config files.

If there are any changes needed to be made, let me know.