### PR TITLE
Update version of Quark MainApplication.java also to 1.0.0

### DIFF
--- a/Quark/src/main/java/xortroll/goldleaf/quark/ui/MainApplication.java
+++ b/Quark/src/main/java/xortroll/goldleaf/quark/ui/MainApplication.java
@@ -48,7 +48,7 @@ import xortroll.goldleaf.quark.usb.cf.CommandFramework;
 import xortroll.goldleaf.quark.usb.cmd.CommandBlock;
 
 public class MainApplication extends Application {
-    public static final Version CurrentVersion = new Version(0, 10, 1);
+    public static final Version CurrentVersion = new Version(1, 0, 0);
 
     private static Config special_path_cfg;
     private static Object special_path_cfg_lock;


### PR DESCRIPTION
I noticed that quark still display 0.10.1 as version. This PR fixes that