### PR TITLE
steal release script from xash3d-fwgs & update ci/cd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,12 @@
-name: Build Goldleaf
-
+name: Build & Deploy Goldleaf
 on: [push, pull_request]
-
 jobs:
-  Goldleaf:
+  build:
+    name: "Build Goldleaf"
     runs-on: ubuntu-latest
     container: devkitpro/devkita64:latest
-
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -32,20 +30,32 @@ jobs:
     - name: Build and install libnx
       run: |
         cd libnx
-        make install -j$(nproc)
+        make install -j$(nproc) -l$(nproc)
 
     - name: Build libusbhsfs dependencies
       run: |
-        make setup -j$(nproc)
+        make setup -j$(nproc) -l$(nproc)
 
     - name: Build Goldleaf
       run: |
         python3 arc/arc.py gen_db default+Goldleaf/include/res/res_Account.rc.hpp+Goldleaf/include/res/res_ETicket.rc.hpp+Goldleaf/include/res/res_NS.rc.hpp+Goldleaf/include/res/res_NFP.rc.hpp+Goldleaf/include/res/res_Goldleaf.rc.hpp
         python3 arc/arc.py gen_cpp rc GLEAF Goldleaf/include/res/res_Generated.gen.hpp
-        make build -j$(nproc)
+        make build -j$(nproc) -l$(nproc)
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v6
       with:
-        name: Goldleaf
         path: Goldleaf/Goldleaf.nro
         if-no-files-found: error
+
+  release:
+    name: "Publish release"
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.event_name == 'push' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Remove old release and upload new release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bash ci-scripts/make_release.sh "${{ github.repository }}" "${{ github.ref_name }}"

--- a/ci-scripts/make_release.sh
+++ b/ci-scripts/make_release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if ! command -v gh > /dev/null; then
+	echo "Install GitHub CLI tool"
+	exit 1
+fi
+
+RELEASE_NAME=$(echo -n $1 | sed -e 's/^.*\///g')
+BRANCH_NAME=$2
+DEFAULT_BRANCH_NAME=master
+
+if [ -z "$RELEASE_NAME" ] || [ -z "$BRANCH_NAME" ]; then
+	echo "Invalid arguments"
+	exit 1
+fi
+
+if [ "$BRANCH_NAME" == "$DEFAULT_BRANCH_NAME" ]; then
+	RELEASE_TAG="continuous"
+else
+	RELEASE_TAG="continuous-$BRANCH_NAME"
+fi
+
+gh release delete "$RELEASE_TAG" \
+	--yes \
+	--cleanup-tag \
+	--repo "$GITHUB_REPOSITORY" || true
+
+gh run download "$GITHUB_RUN_ID" \
+	--dir artifacts/ \
+	--repo "$GITHUB_REPOSITORY"
+
+pushd artifacts/ || exit 1
+echo "Artifacts:"
+ls
+for i in $(find -mindepth 1 -maxdepth 1 -type d); do
+	mv "$i"/* .
+	rmdir "$i"
+done
+echo "Repackaged artifacts:"
+ls -R
+popd || exit 1
+
+git log -1 --pretty=format:'%h%nBy %aN at %ai' > release-notes
+
+sleep 10s
+gh release create "$RELEASE_TAG" artifacts/* \
+	--title "$RELEASE_NAME Continuous $BRANCH_NAME build" \
+	--notes-file release-notes \
+	--target "$GITHUB_SHA" \
+	--repo "$GITHUB_REPOSITORY" \
+	--prerelease


### PR DESCRIPTION
Continuous deployment flow in form of 'Pre-releases'.
For your consideration.
Looks like this: https://github.com/developersu/Goldleaf/releases

Pros: 
* it's fun
* latest releases for anyone who wants to run latest builds here and now

Cons: 
* floods on GH landing page

Requires GITHUB_TOKEN generation & setup. I did it like this:
<img width="910" height="1024" alt="изображение" src="https://github.com/user-attachments/assets/a56cbf16-65c9-4631-89d8-4a1b73751f19" />
(yeah, it might be obvious, but it took me some time)