### PR TITLE
Unatended batch install

### DIFF
--- a/Goldleaf/include/ui/ui_InstallLayout.hpp
+++ b/Goldleaf/include/ui/ui_InstallLayout.hpp
@@ -31,10 +31,18 @@ namespace ui {
             pu::ui::elm::TextBlock::Ref speed_info_text;
 
         public:
+            struct BatchInstallOptions {
+                bool is_batch_install = false;
+                bool skip_if_installed = false;
+                bool should_prompt_delete = false;
+                bool should_delete_after_install = false;
+            };
+
             InstallLayout();
             PU_SMART_CTOR(InstallLayout)
 
-            bool StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation = false, const bool skip_if_already_installed = false);
+            bool StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation, const BatchInstallOptions &batch_install_options);
+            bool StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation = false);
     };
 
 }

--- a/Goldleaf/romfs/Strings/en-US.json
+++ b/Goldleaf/romfs/Strings/en-US.json
@@ -540,5 +540,7 @@
     "USB 1.0 (Low)",
     "USB 1.1 (Full)",
     "USB 2.0 (High)",
-    "USB 3.0 (Super)"
+    "USB 3.0 (Super)",
+    "Do you want to delete the NSP files after installing them?",
+    "Ask for each file"
 ]

--- a/Goldleaf/romfs/Strings/es-419.json
+++ b/Goldleaf/romfs/Strings/es-419.json
@@ -540,5 +540,7 @@
     "USB 1.0 (Low)",
     "USB 1.1 (Full)",
     "USB 2.0 (High)",
-    "USB 3.0 (Super)"
+    "USB 3.0 (Super)",
+    "¿Desea eliminar los archivos NSP después de instalarlos?",
+    "Preguntar por cada archivo"
 ]

--- a/Goldleaf/source/ui/ui_BrowserLayout.cpp
+++ b/Goldleaf/source/ui/ui_BrowserLayout.cpp
@@ -604,6 +604,23 @@ namespace ui {
                         }
                         const bool skip_if_installed = (option_skip == 0);
 
+                        const auto option_delete_behavior = g_MainApplication->DisplayDialog(
+                            cfg::Strings.GetString(77), 
+                            cfg::Strings.GetString(542), 
+                            { 
+                                cfg::Strings.GetString(543), 
+                                cfg::Strings.GetString(111), 
+                                cfg::Strings.GetString(112),
+                                cfg::Strings.GetString(18)
+                            }, true);
+                        
+                        if(option_delete_behavior < 0) {
+                            return;
+                        }
+
+                        const bool should_prompt_delete = (option_delete_behavior == 0);
+                        const bool should_delete_after_install = (option_delete_behavior == 1);
+
                         // const auto scan_subdirs = g_MainApplication->DisplayDialog("Install", "Scan subdirectories for NSP files?", { "Yes", "No", "Cancel" }, true);
                         // if(scan_subdirs < 0) {
                         //     return;
@@ -622,7 +639,14 @@ namespace ui {
                                 return;
                             }
                             g_MainApplication->ShowLayout(g_MainApplication->GetInstallLayout());
-                            const auto installed = g_MainApplication->GetInstallLayout()->StartInstall(nsp_path, pres_nsp_path, this->cur_exp, dst, true, skip_if_installed);
+
+                            const InstallLayout::BatchInstallOptions batchInstallOptions = {
+                                .is_batch_install = true,
+                                .skip_if_installed = skip_if_installed,
+                                .should_prompt_delete = should_prompt_delete,
+                                .should_delete_after_install = should_delete_after_install
+                            };
+                            const auto installed = g_MainApplication->GetInstallLayout()->StartInstall(nsp_path, pres_nsp_path, this->cur_exp, dst, true, batchInstallOptions);
                             if(installed) {
                                 any_installed = true;
                             }

--- a/Goldleaf/source/ui/ui_InstallLayout.cpp
+++ b/Goldleaf/source/ui/ui_InstallLayout.cpp
@@ -480,7 +480,6 @@ namespace ui {
             }
             else if(batch_install_options.should_delete_after_install) {
                 exp->DeleteFile(path);
-                g_MainApplication->ShowNotification(cfg::Strings.GetString(129));
             }
         }
 

--- a/Goldleaf/source/ui/ui_InstallLayout.cpp
+++ b/Goldleaf/source/ui/ui_InstallLayout.cpp
@@ -272,7 +272,11 @@ namespace ui {
         this->speed_info_text->SetColor(g_Settings.GetColorScheme().text);
     }
 
-    bool InstallLayout::StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation, const bool skip_if_already_installed) {
+    bool InstallLayout::StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation) {
+        return StartInstall(path, pres_path, exp, storage_id, omit_confirmation, BatchInstallOptions{});
+    }
+
+    bool InstallLayout::StartInstall(const std::string &path, const std::string &pres_path, fs::Explorer *exp, const NcmStorageId storage_id, const bool omit_confirmation, const BatchInstallOptions &batch_install_options) {
         g_MainApplication->LoadCommonIconMenuData(true, cfg::Strings.GetString(77), CommonIconKind::Storage, cfg::Strings.GetString(145) + " " + pres_path);
         ScopeGuard on_exit([&]() {
             // Just in case
@@ -286,7 +290,7 @@ namespace ui {
         auto rc = nsp_installer.PrepareInstallation();
         if(R_FAILED(rc)) {
             if(rc == rc::goldleaf::ResultContentAlreadyInstalled) {
-                if(skip_if_already_installed) {
+                if(batch_install_options.skip_if_installed) {
                     return false;
                 }
 
@@ -467,8 +471,16 @@ namespace ui {
         else if(do_install) {
             g_MainApplication->ShowNotification(cfg::Strings.GetString(150));
 
-            if(g_Settings.json_settings.installs.value().show_deletion_prompt_after_install.value()) {
+            const bool is_prompt_delete_global_setting_enabled = g_Settings.json_settings.installs.value().show_deletion_prompt_after_install.value();
+            const bool should_prompt_delete = (is_prompt_delete_global_setting_enabled && !batch_install_options.is_batch_install) 
+                                                || (batch_install_options.is_batch_install && batch_install_options.should_prompt_delete);
+            
+            if(should_prompt_delete) {
                 g_MainApplication->GetBrowserLayout()->PromptDeleteFile(path);
+            }
+            else if(batch_install_options.should_delete_after_install) {
+                exp->DeleteFile(path);
+                g_MainApplication->ShowNotification(cfg::Strings.GetString(129));
             }
         }
 


### PR DESCRIPTION
Added a way to make batch installation completely unatended, it overrides global setting on batch installs for prompting nsp deletion after install.

A new dialog was added after the "Would you like to automatically skip already installed NSPs?" dialog.

New dialog added with properties:
  Title: NSP installation
  Content: Do you want to delete the NSP files after installing them?
  Options: 
    1. Ask for each file
           Asks if the file should be removed after each install
    2. Yes: 
           Removes the file automatically after installing without prompting
    3. No: 
           Doesnt remove the file after install without prompting
    4. Cancel:
           Stops the process

This dialog is only present on batch installs, single nsp install functionality remains the same.

added support for en-US and es-419.